### PR TITLE
Add definition of variables

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,27 @@
+variable "access_key" {
+  type = string
+}
+
+variable "secret_key" {
+  type = string
+}
+
+variable "ami" {
+  type = string
+}
+
+variable "subnet_id" {
+  type = string
+}
+
+variable "identity" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "vpc_security_group_id" {
+  type = string
+}


### PR DESCRIPTION
This removes the following deprecation warnings:

```
Warning: Values for undeclared variables

In addition to the other similar warnings shown, 5 other variable(s) defined
without being declared.


Warning: Value for undeclared variable

  on terraform.tfvars line 4:
   4: subnet_id         = "subnet-027dbc9fbe9e751db"

The root module does not declare a variable named "subnet_id". To use this
value, add a "variable" block to the configuration.

Using a variables file to set an undeclared variable is deprecated and will
become an error in a future release. If you wish to provide certain "global"
settings to all configurations in your organization, use TF_VAR_...
environment variables to set these instead.


Warning: Value for undeclared variable

  on terraform.tfvars line 5:
   5: identity          = "tf-training-radek-ant"

The root module does not declare a variable named "identity". To use this
value, add a "variable" block to the configuration.

Using a variables file to set an undeclared variable is deprecated and will
become an error in a future release. If you wish to provide certain "global"
settings to all configurations in your organization, use TF_VAR_...
environment variables to set these instead.


Warning: Value for undeclared variable

  on terraform.tfvars line 6:
   6: region            = "eu-central-1"

The root module does not declare a variable named "region". To use this value,
add a "variable" block to the configuration.

Using a variables file to set an undeclared variable is deprecated and will
become an error in a future release. If you wish to provide certain "global"
settings to all configurations in your organization, use TF_VAR_...
environment variables to set these instead.
```